### PR TITLE
Update for SMAPI 1.9 & streamline build

### DIFF
--- a/src/zDailyIncrease/Properties/AssemblyInfo.cs
+++ b/src/zDailyIncrease/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.3")]
-[assembly: AssemblyFileVersion("1.2.0.3")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]

--- a/src/zDailyIncrease/SocialConfig.cs
+++ b/src/zDailyIncrease/SocialConfig.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using StardewModdingAPI.Advanced;
-
-namespace zDailyIncrease
+﻿namespace zDailyIncrease
 {
   public class SocialConfig
   {

--- a/src/zDailyIncrease/manifest.json
+++ b/src/zDailyIncrease/manifest.json
@@ -3,9 +3,9 @@
   "Author": "Nire \"thakyZ\" Inicana",
   "Version": {
     "MajorVersion": 1,
-    "MinorVersion": 2,
-    "PacthVersion": 0,
-    "Build": 3
+    "MinorVersion": 3,
+    "PatchVersion": 0,
+    "Build": null
   },
   "Description": "A rendition to the original daily increase mod",
   "UniqueID": "zdailyincrease",

--- a/src/zDailyIncrease/manifest.json
+++ b/src/zDailyIncrease/manifest.json
@@ -1,15 +1,13 @@
 ﻿{
   "Name": "zDailyIncrease",
   "Author": "Nire \"thakyZ\" Inicana",
-  "Version":
-  {
+  "Version": {
     "MajorVersion": 1,
     "MinorVersion": 2,
     "PacthVersion": 0,
     "Build": 3
   },
   "Description": "A rendition to the original daily increase mod",
-  "PerSaveConfigs": false,
   "UniqueID": "zdailyincrease",
   "EntryDll": "zDailyIncrease.dll"
 }

--- a/src/zDailyIncrease/packages.config
+++ b/src/zDailyIncrease/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.2.0" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.5.0" targetFramework="net45" />
 </packages>

--- a/src/zDailyIncrease/zDailyIncrease.cs
+++ b/src/zDailyIncrease/zDailyIncrease.cs
@@ -17,8 +17,6 @@ namespace zDailyIncrease
 
     public Farmer Player => Game1.player;
 
-    public Game1 TheGame => Program.gamePtr;
-
     public Random rnd = new Random();
 
     public Dictionary<string, int> prevFriends;
@@ -26,9 +24,9 @@ namespace zDailyIncrease
     public override void Entry(IModHelper helper)
     {
       ModConfig = helper.ReadConfig<SocialConfig>();
-      GameEvents.OneSecondTick += new EventHandler(GameEvents_OneSecondTick);
-      TimeEvents.OnNewDay += new EventHandler<EventArgsNewDay>(GameEvents_OnNewDay);
-      Monitor.Log("zDailyIncrease => Initialized", LogLevel.Debug);
+      GameEvents.OneSecondTick += this.GameEvents_OneSecondTick;
+      TimeEvents.AfterDayStarted += this.OnNewDay;
+      Monitor.Log("zDailyIncrease => Initialized");
       // This calculation needs to be triggered at the end of the day / before saving
     }
 
@@ -39,15 +37,6 @@ namespace zDailyIncrease
         return;
       }
       OneSecondUpdate();
-    }
-
-    private void GameEvents_OnNewDay(object sender, EventArgsNewDay e)
-    {
-      if (!Game1.hasLoadedGame)
-      {
-        return;
-      }
-      OnNewDay(sender, e);
     }
 
     private void OneSecondUpdate()
@@ -61,7 +50,7 @@ namespace zDailyIncrease
           //{
           //  serializableDictionary. = (KeyValuePair<string, int[]> p) => p.Key.ToString();
           //}
-          prevFriends = serializableDictionary.ToDictionary((KeyValuePair<string, int[]> p) => p.Key.ToString(), (KeyValuePair<string, int[]> p) => p.Value[0]);
+          prevFriends = serializableDictionary.ToDictionary(p => p.Key.ToString(), p => p.Value[0]);
         }
         foreach (KeyValuePair<string, int[]> friendship in Player.friendships)
         {
@@ -79,15 +68,12 @@ namespace zDailyIncrease
         //{
         //  Cheats.<> c.<> 9__9_3 = (KeyValuePair<string, int[]> p) => p.Key.ToString();
         //}
-        prevFriends = serializableDictionary1.ToDictionary((KeyValuePair<string, int[]> p) => p.Key.ToString(), (KeyValuePair<string, int[]> p) => p.Value[0]);
+        prevFriends = serializableDictionary1.ToDictionary(p => p.Key.ToString(), p => p.Value[0]);
       }
     }
 
-    private void OnNewDay(object sender, EventArgsNewDay e)
+    private void OnNewDay(object sender, EventArgs e)
     {
-      // So only perform action if e.IsNewDay = true as per SMAPI doc
-      if (ModConfig.enabled && e.IsNewDay == true)
-      {
         Monitor.Log($"zDailyIncrease randomIncrease value is: {ModConfig.randomIncrease}", LogLevel.Trace);
 
         Monitor.Log($"{Environment.NewLine}Friendship increaser enabled. Starting friendship calculation.{Environment.NewLine}", LogLevel.Info);
@@ -167,7 +153,6 @@ namespace zDailyIncrease
         }
 
         Monitor.Log($"{Environment.NewLine}Finished friendship calculation.{Environment.NewLine}", LogLevel.Info);
-      }
     }
   }
 }

--- a/src/zDailyIncrease/zDailyIncrease.csproj
+++ b/src/zDailyIncrease/zDailyIncrease.csproj
@@ -35,21 +35,7 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Stardew Valley">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\Stardew Valley.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="StardewModdingAPI">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\StardewModdingAPI.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/zDailyIncrease/zDailyIncrease.csproj
+++ b/src/zDailyIncrease/zDailyIncrease.csproj
@@ -64,12 +64,12 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/zDailyIncrease/zDailyIncrease.csproj
+++ b/src/zDailyIncrease/zDailyIncrease.csproj
@@ -57,11 +57,13 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
   <Target Name="AfterBuild">
+    <PropertyGroup>
+      <ModPath>$(GamePath)\Mods\$(TargetName)</ModPath>
+    </PropertyGroup>
+    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll" DestinationFolder="$(ModPath)" />
+    <Copy SourceFiles="$(TargetDir)\$(TargetName).pdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).pdb')" />
+    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
+    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
   </Target>
-  -->
 </Project>


### PR DESCRIPTION
zDailyIncrease no longer works in the latest versions of SMAPI. This pull request...

- Updates the code to SMAPI 1.9+.
- Adds a build task which copies the mod into the `Mods` folder on build.
- Updates the [mod build package](https://github.com/Pathoschild/Stardew.ModBuildConfig) and removes unneeded references.
- Updates the mod version to 1.3.

If those changes look fine, can you release [zDailyIncrease 1.3.zip](https://github.com/thakyZ/zDailyIncrease/files/924107/zDailyIncrease.1.3.zip) for players to use?